### PR TITLE
Bugfix: Adopted batch size calculation to handle possible negative values

### DIFF
--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/synchronization/LocalToDestinationSynchronizer.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/synchronization/LocalToDestinationSynchronizer.kt
@@ -132,7 +132,7 @@ internal class LocalToDestinationSynchronizer(
         val queueSize = queue.size()
         val batchSize = batchSizeProvider.getBatchSize()
         return when {
-            queueSize == 0 -> emptyList()
+            queueSize <= 0 -> emptyList()
             queueSize <= batchSize -> pollNElementsFromQueue(queueSize, queue)
             else -> pollNElementsFromQueue(batchSize, queue)
         }


### PR DESCRIPTION
## What?
Adopted batch size calculation to handle possible negative values

## Why?
Because during integration tests run on CI, such situation happened:

```
2023-10-04T11:10:40.5689068Z     11:10:40.529 [localToDestination-sourceDb.newStateTestCollection] ERROR p.a.t.m.c.s.LocalToDestinationSynchronizer - Error during local to destination synchronization for [source: sourceDb.newStateTestCollection, destination: destinationDb.newStateTestCollection]. Stopping synchronization for this collection
2023-10-04T11:10:40.5690352Z     java.lang.IllegalArgumentException: Illegal Capacity: -1
2023-10-04T11:10:40.5690901Z     	at java.base/java.util.ArrayList.<init>(ArrayList.java:158)
2023-10-04T11:10:40.5691862Z     	at pl.allegro.tech.mongomigrationstream.core.synchronization.LocalToDestinationSynchronizer.pollNElementsFromQueue(LocalToDestinationSynchronizer.kt:143)
2023-10-04T11:10:40.5693184Z     	at pl.allegro.tech.mongomigrationstream.core.synchronization.LocalToDestinationSynchronizer.pollBatchFromQueue(LocalToDestinationSynchronizer.kt:136)
2023-10-04T11:10:40.5694711Z     	at pl.allegro.tech.mongomigrationstream.core.synchronization.LocalToDestinationSynchronizer.handleEventsFromQueue(LocalToDestinationSynchronizer.kt:103)
2023-10-04T11:10:40.5696159Z     	at pl.allegro.tech.mongomigrationstream.core.synchronization.LocalToDestinationSynchronizer.startCollectionSynchronization$lambda$2(LocalToDestinationSynchronizer.kt:91)
2023-10-04T11:10:40.5697277Z     	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
2023-10-04T11:10:40.5707044Z     	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
2023-10-04T11:10:40.5707622Z     	at java.base/java.lang.Thread.run(Thread.java:829)
```

```kotlin
private fun pollBatchFromQueue(queue: EventQueue<ChangeEvent>): List<ChangeEvent> {
    val queueSize = queue.size()
    val batchSize = batchSizeProvider.getBatchSize()
    return when {
        queueSize <= 0 -> emptyList() // most probably the 'queueSize' value could be -1 from the Exception above
        queueSize <= batchSize -> pollNElementsFromQueue(queueSize, queue)
        else -> pollNElementsFromQueue(batchSize, queue)
    }
}
```