### PR TITLE
Add additional flags to mongodump and mongorestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ val migrator = MongoMigrationStream(
       configuration.mongoToolsPath,
       configuration.queueFactoryType,
       startMongoMigrationStreamInfo.dumpReadPreference,
-      batchSizeProvider
+      batchSizeProvider,
+      false
     ),
     stateConfig = StateConfig(stateEventHandler)
   ),
@@ -87,6 +88,7 @@ perform.synchronization.validators=DbAvailability,DestinationCollectionMissing,S
 custom.rootPath=/tmp/mongomigrationstream/
 custom.queue.factory=BiqQueueFactory
 custom.dumpReadPreference=primary
+custom.isCompressionEnabled=false
 custom.batchSize=1000
 
 collections.source=collection1,collection2

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ val migrator = MongoMigrationStream(
       configuration.queueFactoryType,
       startMongoMigrationStreamInfo.dumpReadPreference,
       batchSizeProvider,
-      false
+      false,
+      1
     ),
     stateConfig = StateConfig(stateEventHandler)
   ),
@@ -89,6 +90,7 @@ custom.rootPath=/tmp/mongomigrationstream/
 custom.queue.factory=BiqQueueFactory
 custom.dumpReadPreference=primary
 custom.isCompressionEnabled=false
+custom.insertionWorkersPerCollection=1
 custom.batchSize=1000
 
 collections.source=collection1,collection2

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Firstly, add _mongo-migration-stream_ as a dependency to your project:
 
 ```gradle
 dependencies {
-    implementation("pl.allegro.tech:mongo-migration-stream:0.6.1")
+    implementation("pl.allegro.tech:mongo-migration-stream:0.9.0")
 }
 ```
 
@@ -71,7 +71,7 @@ migrator.stop()     // Stops a migration
 Firstly, you need a _mongo-migration-stream_ JAR. You can either:
 
 - Download it from the [newest release page](https://github.com/allegro/mongo-migration-stream/releases), or
-- Clone project repository and execute `./gradlew fatJar` command in root project directory - a JAR file should
+- Clone project repository and execute `./gradlew shadowJar` command in root project directory - a JAR file should
   appear in `mongo-migration-stream-cli/build/libs/` directory.
 
 Secondly, you have to define a properties file specifying migration details.

--- a/config/local/application.properties
+++ b/config/local/application.properties
@@ -7,6 +7,7 @@ perform.synchronization.validators=DbAvailability,DestinationCollectionMissing,S
 custom.rootPath=/tmp/mongomigrationstream/
 custom.queue.factory=BiqQueueFactory
 custom.dumpReadPreference=primary
+custom.isCompressionEnabled=false
 custom.batchSize=1000
 
 collections.source=collection1,collection2

--- a/config/local/application.properties
+++ b/config/local/application.properties
@@ -8,6 +8,7 @@ custom.rootPath=/tmp/mongomigrationstream/
 custom.queue.factory=BiqQueueFactory
 custom.dumpReadPreference=primary
 custom.isCompressionEnabled=false
+custom.insertionWorkersPerCollection=1
 custom.batchSize=1000
 
 collections.source=collection1,collection2

--- a/mongo-migration-stream-cli/src/main/kotlin/pl/allegro/tech/mongomigrationstream/properties/ApplicationPropertiesReader.kt
+++ b/mongo-migration-stream-cli/src/main/kotlin/pl/allegro/tech/mongomigrationstream/properties/ApplicationPropertiesReader.kt
@@ -56,6 +56,7 @@ internal object ApplicationPropertiesReader {
         val queueFactoryType = properties.requiredProperty("custom.queue.factory", "InMemoryCustomQueueFactory")
         val dumpReadPreference = properties.requiredProperty("custom.dumpReadPreference", ReadPreference.primary().name)
         val isCompressionEnabled = properties.getBoolean("custom.isCompressionEnabled", false)
+        val insertionWorkersPerCollection = properties.getInt("custom.insertionWorkersPerCollection", 1)
         val batchSize = properties.requiredProperty("custom.batchSize", "1000").toIntOrNull() ?: 1000
 
         return PerformerProperties(
@@ -64,7 +65,8 @@ internal object ApplicationPropertiesReader {
             queueFactory = QueueFactoryTypeMapper.from(queueFactoryType),
             dumpReadPreference = ReadPreference.valueOf(dumpReadPreference),
             batchSizeProvider = ConstantValueBatchSizeProvider(batchSize),
-            isCompressionEnabled = isCompressionEnabled
+            isCompressionEnabled = isCompressionEnabled,
+            insertionWorkersPerCollection = insertionWorkersPerCollection
         )
     }
 

--- a/mongo-migration-stream-cli/src/main/kotlin/pl/allegro/tech/mongomigrationstream/properties/ApplicationPropertiesReader.kt
+++ b/mongo-migration-stream-cli/src/main/kotlin/pl/allegro/tech/mongomigrationstream/properties/ApplicationPropertiesReader.kt
@@ -55,14 +55,16 @@ internal object ApplicationPropertiesReader {
         val mongoToolsPath = properties.requiredProperty("custom.mongoToolsPath", "")
         val queueFactoryType = properties.requiredProperty("custom.queue.factory", "InMemoryCustomQueueFactory")
         val dumpReadPreference = properties.requiredProperty("custom.dumpReadPreference", ReadPreference.primary().name)
+        val isCompressionEnabled = properties.getBoolean("custom.isCompressionEnabled", false)
         val batchSize = properties.requiredProperty("custom.batchSize", "1000").toIntOrNull() ?: 1000
 
         return PerformerProperties(
-            rootPath,
-            mongoToolsPath,
-            QueueFactoryTypeMapper.from(queueFactoryType),
-            ReadPreference.valueOf(dumpReadPreference),
-            ConstantValueBatchSizeProvider(batchSize)
+            rootPath = rootPath,
+            mongoToolsPath = mongoToolsPath,
+            queueFactory = QueueFactoryTypeMapper.from(queueFactoryType),
+            dumpReadPreference = ReadPreference.valueOf(dumpReadPreference),
+            batchSizeProvider = ConstantValueBatchSizeProvider(batchSize),
+            isCompressionEnabled = isCompressionEnabled
         )
     }
 
@@ -85,11 +87,11 @@ internal object ApplicationPropertiesReader {
             .toSet()
 
         return GeneralProperties(
-            shouldPerformMigration,
-            shouldPerformSynchronization,
-            synchronizationHandlers,
-            synchronizationDetectors,
-            validators
+            shouldPerformTransfer = shouldPerformMigration,
+            shouldPerformSynchronization = shouldPerformSynchronization,
+            synchronizationHandlers = synchronizationHandlers,
+            synchronizationDetectors = synchronizationDetectors,
+            databaseValidators = validators
         )
     }
 

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/configuration/PerformerProperties.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/configuration/PerformerProperties.kt
@@ -8,7 +8,8 @@ data class PerformerProperties(
     val mongoToolsPath: String,
     val queueFactory: QueueFactoryType,
     val dumpReadPreference: ReadPreference,
-    val batchSizeProvider: BatchSizeProvider
+    val batchSizeProvider: BatchSizeProvider,
+    val isCompressionEnabled: Boolean,
 ) {
     sealed class QueueFactoryType
     object InMemoryQueueFactoryType : QueueFactoryType()

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/configuration/PerformerProperties.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/configuration/PerformerProperties.kt
@@ -3,6 +3,9 @@ package pl.allegro.tech.mongomigrationstream.configuration
 import com.mongodb.ReadPreference
 import pl.allegro.tech.mongomigrationstream.core.synchronization.BatchSizeProvider
 
+const val MIN_INSERTION_WORKERS_PER_COLLECTION = 1
+const val MAX_INSERTION_WORKERS_PER_COLLECTION = 10
+
 data class PerformerProperties(
     val rootPath: String,
     val mongoToolsPath: String,
@@ -10,7 +13,17 @@ data class PerformerProperties(
     val dumpReadPreference: ReadPreference,
     val batchSizeProvider: BatchSizeProvider,
     val isCompressionEnabled: Boolean,
+    val insertionWorkersPerCollection: Int
 ) {
+    init {
+        if (insertionWorkersPerCollection < MIN_INSERTION_WORKERS_PER_COLLECTION || insertionWorkersPerCollection > MAX_INSERTION_WORKERS_PER_COLLECTION) {
+            throw IllegalArgumentException(
+                "Number of insertion workers per collection is set to: [$insertionWorkersPerCollection], " +
+                    "but should be between [$MIN_INSERTION_WORKERS_PER_COLLECTION and $MAX_INSERTION_WORKERS_PER_COLLECTION]."
+            )
+        }
+    }
+
     sealed class QueueFactoryType
     object InMemoryQueueFactoryType : QueueFactoryType()
     object BiqQueueFactoryType : QueueFactoryType()

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/transfer/MongoToolsTransfer.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/transfer/MongoToolsTransfer.kt
@@ -43,6 +43,7 @@ internal class MongoToolsTransfer(
     private val mongoToolsPath = properties.performerProperties.mongoToolsPath
     private val absoluteDumpPath = Path.of(properties.performerProperties.rootPath, MigrationPaths.DUMPS_DIR).toAbsolutePath()
     private val dumpReadPreference = properties.performerProperties.dumpReadPreference
+    private val isCompressionEnabled = properties.performerProperties.isCompressionEnabled
     private val executor = MigrationExecutors.createMigratorExecutor(sourceDbCollection)
     private val commandRunners: MutableList<CommandRunner> = mutableListOf()
 
@@ -107,7 +108,8 @@ internal class MongoToolsTransfer(
         mongoToolsPath = mongoToolsPath,
         dumpPath = absoluteDumpPath.toString(),
         readPreference = dumpReadPreference.name,
-        passwordConfigPath = passwordConfigFiles.sourceConfigPath
+        passwordConfigPath = passwordConfigFiles.sourceConfigPath,
+        isCompressionEnabled = isCompressionEnabled
     )
 
     private fun runRestore(): CommandResult = runCommand(
@@ -121,7 +123,8 @@ internal class MongoToolsTransfer(
         dbCollection = destinationDbCollection,
         mongoToolsPath = mongoToolsPath,
         dumpPath = resolveCreatedDumpPath(absoluteDumpPath),
-        passwordConfigPath = passwordConfigFiles.destinationConfigPath
+        passwordConfigPath = passwordConfigFiles.destinationConfigPath,
+        isCompressionEnabled = isCompressionEnabled
     )
 
     private fun resolveCreatedDumpPath(absoluteDumpPath: Path): String = absoluteDumpPath

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/transfer/MongoToolsTransfer.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/transfer/MongoToolsTransfer.kt
@@ -44,6 +44,7 @@ internal class MongoToolsTransfer(
     private val absoluteDumpPath = Path.of(properties.performerProperties.rootPath, MigrationPaths.DUMPS_DIR).toAbsolutePath()
     private val dumpReadPreference = properties.performerProperties.dumpReadPreference
     private val isCompressionEnabled = properties.performerProperties.isCompressionEnabled
+    private val insertionWorkersPerCollection = properties.performerProperties.insertionWorkersPerCollection
     private val executor = MigrationExecutors.createMigratorExecutor(sourceDbCollection)
     private val commandRunners: MutableList<CommandRunner> = mutableListOf()
 
@@ -108,8 +109,8 @@ internal class MongoToolsTransfer(
         mongoToolsPath = mongoToolsPath,
         dumpPath = absoluteDumpPath.toString(),
         readPreference = dumpReadPreference.name,
+        isCompressionEnabled = isCompressionEnabled,
         passwordConfigPath = passwordConfigFiles.sourceConfigPath,
-        isCompressionEnabled = isCompressionEnabled
     )
 
     private fun runRestore(): CommandResult = runCommand(
@@ -123,8 +124,9 @@ internal class MongoToolsTransfer(
         dbCollection = destinationDbCollection,
         mongoToolsPath = mongoToolsPath,
         dumpPath = resolveCreatedDumpPath(absoluteDumpPath),
+        isCompressionEnabled = isCompressionEnabled,
+        insertionWorkersPerCollection = insertionWorkersPerCollection,
         passwordConfigPath = passwordConfigFiles.destinationConfigPath,
-        isCompressionEnabled = isCompressionEnabled
     )
 
     private fun resolveCreatedDumpPath(absoluteDumpPath: Path): String = absoluteDumpPath

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/transfer/command/Command.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/transfer/command/Command.kt
@@ -18,7 +18,8 @@ internal sealed class Command {
         private val mongoToolsPath: String,
         private val dumpPath: String,
         private val readPreference: String,
-        private val passwordConfigPath: String?
+        private val passwordConfigPath: String?,
+        private val isCompressionEnabled: Boolean?,
     ) : Command() {
         override fun prepareCommand(): List<String> = listOf(
             mongoToolsPath + "mongodump",
@@ -27,7 +28,9 @@ internal sealed class Command {
             "--collection", dbCollection.collectionName,
             "--out", dumpPath,
             "--readPreference", readPreference
-        ) + credentialsIfNotNull(dbProperties.authenticationProperties, passwordConfigPath)
+        ) + credentialsIfNotNull(
+            dbProperties.authenticationProperties, passwordConfigPath
+        ) + gzipIfNotNull(isCompressionEnabled)
 
         override fun commandName(): String {
             return "dump"
@@ -39,7 +42,8 @@ internal sealed class Command {
         private val dbCollection: DbCollection,
         private val mongoToolsPath: String,
         private val dumpPath: String,
-        private val passwordConfigPath: String?
+        private val passwordConfigPath: String?,
+        private val isCompressionEnabled: Boolean?,
     ) : Command() {
         override fun prepareCommand(): List<String> = listOf(
             mongoToolsPath + "mongorestore",
@@ -48,7 +52,9 @@ internal sealed class Command {
             "--collection", dbCollection.collectionName,
             "--dir", dumpPath,
             "--noIndexRestore"
-        ) + credentialsIfNotNull(dbProperties.authenticationProperties, passwordConfigPath)
+        ) + credentialsIfNotNull(
+            dbProperties.authenticationProperties, passwordConfigPath
+        ) + gzipIfNotNull(isCompressionEnabled)
 
         override fun commandName(): String {
             return "restore"
@@ -66,4 +72,6 @@ internal sealed class Command {
                 "--authenticationDatabase", authenticationProperties.authDbName
             )
         } else emptyList()
+
+    protected fun gzipIfNotNull(isCompressionEnabled: Boolean?): List<String> = if (isCompressionEnabled == true) listOf("--gzip") else emptyList()
 }

--- a/mongo-migration-stream-core/src/test/kotlin/pl/allegro/tech/mongomigrationstream/configuration/PerformerPropertiesTest.kt
+++ b/mongo-migration-stream-core/src/test/kotlin/pl/allegro/tech/mongomigrationstream/configuration/PerformerPropertiesTest.kt
@@ -1,0 +1,38 @@
+package pl.allegro.tech.mongomigrationstream.configuration
+
+import com.mongodb.ReadPreference
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.ShouldSpec
+import pl.allegro.tech.mongomigrationstream.core.synchronization.ConstantValueBatchSizeProvider
+
+internal class PerformerPropertiesTest : ShouldSpec({
+    should("create PerformerProperties") {
+        shouldNotThrowAny {
+            PerformerProperties(
+                rootPath = "/",
+                mongoToolsPath = "/",
+                queueFactory = PerformerProperties.InMemoryQueueFactoryType,
+                dumpReadPreference = ReadPreference.primary(),
+                batchSizeProvider = ConstantValueBatchSizeProvider(1000),
+                isCompressionEnabled = false,
+                insertionWorkersPerCollection = 1
+            )
+        }
+    }
+
+    should("throw IllegalArgumentException when creating PerformerProperties with invalid number of insertionWorkersPerCollection") {
+        val invalidNumberOfInsertionWorkersPerCollection = -1
+        shouldThrow<IllegalArgumentException> {
+            PerformerProperties(
+                rootPath = "/",
+                mongoToolsPath = "/",
+                queueFactory = PerformerProperties.InMemoryQueueFactoryType,
+                dumpReadPreference = ReadPreference.primary(),
+                batchSizeProvider = ConstantValueBatchSizeProvider(1000),
+                isCompressionEnabled = false,
+                insertionWorkersPerCollection = invalidNumberOfInsertionWorkersPerCollection
+            )
+        }
+    }
+})

--- a/mongo-migration-stream-core/src/test/kotlin/pl/allegro/tech/mongomigrationstream/core/transfer/command/DumpCommandTest.kt
+++ b/mongo-migration-stream-core/src/test/kotlin/pl/allegro/tech/mongomigrationstream/core/transfer/command/DumpCommandTest.kt
@@ -10,20 +10,18 @@ import pl.allegro.tech.mongomigrationstream.core.transfer.command.Command.MongoD
 internal class DumpCommandTest : ShouldSpec({
     should("create dump command") {
         // Given:
-        val properties = MongoProperties(
-            "uri",
-            "dbName",
-        )
+        val properties = MongoProperties("uri", "dbName")
         val collectionToMigrate = "collection"
         val dumpPath = "/dumpPath"
         val readPreference = "primary"
         val mongoDumpCommand = MongoDumpCommand(
-            properties,
-            DbCollection(properties.dbName, collectionToMigrate),
-            "",
-            dumpPath,
-            readPreference,
-            null
+            dbProperties = properties,
+            dbCollection = DbCollection(properties.dbName, collectionToMigrate),
+            mongoToolsPath = "",
+            dumpPath = dumpPath,
+            readPreference = readPreference,
+            passwordConfigPath = null,
+            isCompressionEnabled = false
         )
         // when:
         val terminalCommand = mongoDumpCommand.prepareCommand()
@@ -41,12 +39,12 @@ internal class DumpCommandTest : ShouldSpec({
     should("should create dump command with auth data") {
         // given:
         val properties = MongoProperties(
-            "uri",
-            "dbName",
-            MongoAuthenticationProperties(
-                "username",
-                "password",
-                "admin"
+            uri = "uri",
+            dbName = "dbName",
+            authenticationProperties = MongoAuthenticationProperties(
+                username = "username",
+                password = "password",
+                authDbName = "admin"
             )
         )
         val collectionToMigrate = "collection"
@@ -54,12 +52,13 @@ internal class DumpCommandTest : ShouldSpec({
         val readPreference = "primary"
         val passwordConfigPath = "/tmp/mongomigrationstream/password_config/dump.config"
         val mongoDumpCommand = MongoDumpCommand(
-            properties,
-            DbCollection(properties.dbName, collectionToMigrate),
-            "",
-            dumpPath,
-            readPreference,
-            passwordConfigPath,
+            dbProperties = properties,
+            dbCollection = DbCollection(properties.dbName, collectionToMigrate),
+            mongoToolsPath = "",
+            dumpPath = dumpPath,
+            readPreference = readPreference,
+            passwordConfigPath = passwordConfigPath,
+            isCompressionEnabled = false
         )
         // when:
         val terminalCommand = mongoDumpCommand.prepareCommand()
@@ -74,6 +73,36 @@ internal class DumpCommandTest : ShouldSpec({
             "--username", properties.authenticationProperties!!.username,
             "--config", passwordConfigPath,
             "--authenticationDatabase", properties.authenticationProperties!!.authDbName,
+        )
+    }
+
+    should("should create dump command with gzip") {
+        // given:
+        val isCompressionEnabled = true
+        val properties = MongoProperties("uri", "dbName")
+        val collectionToMigrate = "collection"
+        val dumpPath = "/dumpPath"
+        val readPreference = "primary"
+        val mongoDumpCommand = MongoDumpCommand(
+            dbProperties = properties,
+            dbCollection = DbCollection(properties.dbName, collectionToMigrate),
+            mongoToolsPath = "",
+            dumpPath = dumpPath,
+            readPreference = readPreference,
+            passwordConfigPath = null,
+            isCompressionEnabled = isCompressionEnabled
+        )
+        // when:
+        val terminalCommand = mongoDumpCommand.prepareCommand()
+        // then:
+        terminalCommand.shouldContainExactly(
+            "mongodump",
+            "--uri", properties.uri,
+            "--db", properties.dbName,
+            "--collection", collectionToMigrate,
+            "--out", dumpPath,
+            "--readPreference", readPreference,
+            "--gzip"
         )
     }
 })

--- a/mongo-migration-stream-core/src/test/kotlin/pl/allegro/tech/mongomigrationstream/core/transfer/command/RestoreCommandTest.kt
+++ b/mongo-migration-stream-core/src/test/kotlin/pl/allegro/tech/mongomigrationstream/core/transfer/command/RestoreCommandTest.kt
@@ -18,8 +18,9 @@ internal class RestoreCommandTest : ShouldSpec({
             dbCollection = DbCollection(properties.dbName, collectionToMigrate),
             mongoToolsPath = "",
             dumpPath = restorePath,
+            isCompressionEnabled = false,
+            insertionWorkersPerCollection = 1,
             passwordConfigPath = null,
-            isCompressionEnabled = false
         )
         // when:
         val terminalCommand = mongoRestoreCommand.prepareCommand()
@@ -53,8 +54,9 @@ internal class RestoreCommandTest : ShouldSpec({
             dbCollection = DbCollection(properties.dbName, collectionToMigrate),
             mongoToolsPath = "",
             dumpPath = restorePath,
+            isCompressionEnabled = false,
+            insertionWorkersPerCollection = 1,
             passwordConfigPath = passwordConfigPath,
-            isCompressionEnabled = false
         )
         // when:
         val terminalCommand = mongoRestoreCommand.prepareCommand()
@@ -83,8 +85,9 @@ internal class RestoreCommandTest : ShouldSpec({
             dbCollection = DbCollection(properties.dbName, collectionToMigrate),
             mongoToolsPath = "",
             dumpPath = restorePath,
+            isCompressionEnabled = isCompressionEnabled,
+            insertionWorkersPerCollection = 1,
             passwordConfigPath = null,
-            isCompressionEnabled = isCompressionEnabled
         )
         // when:
         val terminalCommand = mongoRestoreCommand.prepareCommand()
@@ -97,6 +100,35 @@ internal class RestoreCommandTest : ShouldSpec({
             "--dir", restorePath,
             "--noIndexRestore",
             "--gzip"
+        )
+    }
+
+    should("create restore command with number of insertion workers per collection") {
+        // given:
+        val numberOfInsertionWorkersPerCollection = 5
+        val properties = MongoProperties("uri", "dbName")
+        val collectionToMigrate = "collection"
+        val restorePath = "/restorePath"
+        val mongoRestoreCommand = MongoRestoreCommand(
+            dbProperties = properties,
+            dbCollection = DbCollection(properties.dbName, collectionToMigrate),
+            mongoToolsPath = "",
+            dumpPath = restorePath,
+            isCompressionEnabled = false,
+            insertionWorkersPerCollection = numberOfInsertionWorkersPerCollection,
+            passwordConfigPath = null,
+        )
+        // when:
+        val terminalCommand = mongoRestoreCommand.prepareCommand()
+        // then:
+        terminalCommand.shouldContainExactly(
+            "mongorestore",
+            "--uri", properties.uri,
+            "--db", properties.dbName,
+            "--collection", collectionToMigrate,
+            "--dir", restorePath,
+            "--noIndexRestore",
+            "--numInsertionWorkersPerCollection", numberOfInsertionWorkersPerCollection.toString()
         )
     }
 })

--- a/mongo-migration-stream-core/src/test/kotlin/pl/allegro/tech/mongomigrationstream/core/transfer/command/RestoreCommandTest.kt
+++ b/mongo-migration-stream-core/src/test/kotlin/pl/allegro/tech/mongomigrationstream/core/transfer/command/RestoreCommandTest.kt
@@ -3,24 +3,23 @@ package pl.allegro.tech.mongomigrationstream.core.transfer.command
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import pl.allegro.tech.mongomigrationstream.configuration.MongoProperties
+import pl.allegro.tech.mongomigrationstream.configuration.MongoProperties.MongoAuthenticationProperties
 import pl.allegro.tech.mongomigrationstream.core.mongo.DbCollection
 import pl.allegro.tech.mongomigrationstream.core.transfer.command.Command.MongoRestoreCommand
 
 internal class RestoreCommandTest : ShouldSpec({
     should("create restore command") {
         // Given:
-        val properties = MongoProperties(
-            "uri",
-            "dbName"
-        )
+        val properties = MongoProperties("uri", "dbName")
         val collectionToMigrate = "collection"
         val restorePath = "/restorePath"
         val mongoRestoreCommand = MongoRestoreCommand(
-            properties,
-            DbCollection(properties.dbName, collectionToMigrate),
-            "",
-            restorePath,
-            null
+            dbProperties = properties,
+            dbCollection = DbCollection(properties.dbName, collectionToMigrate),
+            mongoToolsPath = "",
+            dumpPath = restorePath,
+            passwordConfigPath = null,
+            isCompressionEnabled = false
         )
         // when:
         val terminalCommand = mongoRestoreCommand.prepareCommand()
@@ -38,23 +37,24 @@ internal class RestoreCommandTest : ShouldSpec({
     should("create restore command with auth data") {
         // given:
         val properties = MongoProperties(
-            "uri",
-            "dbName",
-            MongoProperties.MongoAuthenticationProperties(
-                "username",
-                "password",
-                "admin"
+            uri = "uri",
+            dbName = "dbName",
+            authenticationProperties = MongoAuthenticationProperties(
+                username = "username",
+                password = "password",
+                authDbName = "admin"
             )
         )
         val collectionToMigrate = "collection"
         val restorePath = "/restorePath"
         val passwordConfigPath = "/tmp/mongomigrationstream/password_config/restore.config"
         val mongoRestoreCommand = MongoRestoreCommand(
-            properties,
-            DbCollection(properties.dbName, collectionToMigrate),
-            "",
-            restorePath,
-            passwordConfigPath
+            dbProperties = properties,
+            dbCollection = DbCollection(properties.dbName, collectionToMigrate),
+            mongoToolsPath = "",
+            dumpPath = restorePath,
+            passwordConfigPath = passwordConfigPath,
+            isCompressionEnabled = false
         )
         // when:
         val terminalCommand = mongoRestoreCommand.prepareCommand()
@@ -69,6 +69,34 @@ internal class RestoreCommandTest : ShouldSpec({
             "--username", properties.authenticationProperties!!.username,
             "--config", passwordConfigPath,
             "--authenticationDatabase", properties.authenticationProperties!!.authDbName,
+        )
+    }
+
+    should("create restore command with gzip") {
+        // given:
+        val isCompressionEnabled = true
+        val properties = MongoProperties("uri", "dbName")
+        val collectionToMigrate = "collection"
+        val restorePath = "/restorePath"
+        val mongoRestoreCommand = MongoRestoreCommand(
+            dbProperties = properties,
+            dbCollection = DbCollection(properties.dbName, collectionToMigrate),
+            mongoToolsPath = "",
+            dumpPath = restorePath,
+            passwordConfigPath = null,
+            isCompressionEnabled = isCompressionEnabled
+        )
+        // when:
+        val terminalCommand = mongoRestoreCommand.prepareCommand()
+        // then:
+        terminalCommand.shouldContainExactly(
+            "mongorestore",
+            "--uri", properties.uri,
+            "--db", properties.dbName,
+            "--collection", collectionToMigrate,
+            "--dir", restorePath,
+            "--noIndexRestore",
+            "--gzip"
         )
     }
 })


### PR DESCRIPTION
## What?
In this PR I've added support for enabling flags available in `mongodump` and `mongorestore`:
- [`--gzip`](https://www.mongodb.com/docs/database-tools/mongorestore/#std-option-mongorestore.--gzip) for `mongodump` and `mongorestore`,
- [`--numInsertionWorkersPerCollection`](https://www.mongodb.com/docs/database-tools/mongorestore/#std-option-mongorestore.--numInsertionWorkersPerCollection) for `mongorestore`

## Why?
To reduce size of dumps created during `mongodump` (`--gzip`), and to fasten restore part (`--numInsertionWorkersPerCollection`)