### PR TITLE
Use full documentKey from Mongo Change Event as query filter

### DIFF
--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/synchronization/ChangeEvent.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/synchronization/ChangeEvent.kt
@@ -2,7 +2,6 @@ package pl.allegro.tech.mongomigrationstream.core.synchronization
 
 import com.mongodb.DBRefCodecProvider
 import com.mongodb.client.model.DeleteOneModel
-import com.mongodb.client.model.Filters
 import com.mongodb.client.model.ReplaceOneModel
 import com.mongodb.client.model.ReplaceOptions
 import com.mongodb.client.model.UpdateOneModel

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/synchronization/ChangeEvent.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/synchronization/ChangeEvent.kt
@@ -42,7 +42,6 @@ internal sealed class ChangeEvent(
         null
     }
 
-    protected fun idFilter() = Filters.eq("_id", documentKey.getValue("_id"))
     protected abstract fun toWriteModelImpl(): WriteModel<BsonDocument>
 
     companion object {
@@ -89,7 +88,7 @@ internal data class InsertReplaceChangeEvent(
     }
 
     override fun toWriteModelImpl(): WriteModel<BsonDocument> = ReplaceOneModel(
-        idFilter(),
+        documentKey,
         document!!,
         ReplaceOptions().upsert(true)
     )
@@ -107,7 +106,7 @@ internal data class DeleteChangeEvent(
             )
     }
 
-    override fun toWriteModelImpl(): WriteModel<BsonDocument> = DeleteOneModel(idFilter())
+    override fun toWriteModelImpl(): WriteModel<BsonDocument> = DeleteOneModel(documentKey)
 }
 
 internal data class UpdateChangeEvent(
@@ -132,7 +131,7 @@ internal data class UpdateChangeEvent(
     }
 
     override fun toWriteModelImpl(): WriteModel<BsonDocument> = UpdateOneModel(
-        idFilter(),
+        documentKey,
         Updates.combine(
             *updatedFields.entries.map { Updates.set(it.key, it.value) }.toTypedArray(),
             *removedFields.map { Updates.unset(it) }.toTypedArray()


### PR DESCRIPTION
## What?

In this PR I've changed query filter from single _"\_id"_ filter to full _documentKey_ from Mongo Change Event.

## Why?

In sharded databases [to perform upsert, you need to provide full shard key in the upsert operation filter](https://www.mongodb.com/docs/manual/reference/method/db.collection.update/#upsert-on-a-sharded-collection). Currently, migrator was only providing _"\_id"_ in the filter.