### PR TITLE
Fix synchronization to sharded destination database

### DIFF
--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/sharding/ShardingInfo.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/sharding/ShardingInfo.kt
@@ -1,0 +1,7 @@
+package pl.allegro.tech.mongomigrationstream.core.sharding
+
+import pl.allegro.tech.mongomigrationstream.core.mongo.DbCollection
+
+internal data class ShardingInfo(
+    val collectionShardingKey: Map<DbCollection, String>
+)

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/synchronization/ChangeEvent.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/synchronization/ChangeEvent.kt
@@ -15,6 +15,7 @@ import com.mongodb.client.model.changestream.OperationType.REPLACE
 import com.mongodb.client.model.changestream.OperationType.UPDATE
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.bson.BsonDocument
+import org.bson.BsonNull
 import org.bson.codecs.BsonCodecProvider
 import org.bson.codecs.BsonValueCodecProvider
 import org.bson.codecs.DocumentCodecProvider
@@ -96,7 +97,7 @@ internal data class InsertReplaceChangeEvent(
         private fun upsertKey(documentKey: BsonDocument, shardingKey: String?): BsonDocument {
             if (shardingKey == null) return documentKey // When no shardingKey, don't change documentKey
             if (documentKey.containsKey(shardingKey)) return documentKey // When sharding key is already in documentKey, don't change documentKey
-            return documentKey.append(shardingKey, null) // When there is no shardingKey, add "shardingKey: null" to documentKey
+            return documentKey.append(shardingKey, BsonNull.VALUE) // When there is no shardingKey, add "shardingKey: null" to documentKey
         }
 
     }

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/synchronization/ChangeEvent.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/core/synchronization/ChangeEvent.kt
@@ -99,7 +99,6 @@ internal data class InsertReplaceChangeEvent(
             if (documentKey.containsKey(shardingKey)) return documentKey // When sharding key is already in documentKey, don't change documentKey
             return documentKey.append(shardingKey, BsonNull.VALUE) // When there is no shardingKey, add "shardingKey: null" to documentKey
         }
-
     }
 
     override fun toWriteModelImpl(): WriteModel<BsonDocument> = ReplaceOneModel(

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/infrastructure/controller/MigrationController.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/infrastructure/controller/MigrationController.kt
@@ -5,11 +5,13 @@ import pl.allegro.tech.mongomigrationstream.configuration.ApplicationProperties
 import pl.allegro.tech.mongomigrationstream.core.cleanup.MigrationCleanup
 import pl.allegro.tech.mongomigrationstream.core.performer.Performer
 import pl.allegro.tech.mongomigrationstream.core.performer.PerformerController
+import pl.allegro.tech.mongomigrationstream.core.sharding.ShardingInfo
 import pl.allegro.tech.mongomigrationstream.core.state.StateInfo
 import pl.allegro.tech.mongomigrationstream.infrastructure.detector.SynchronizationDetectorFactory
 import pl.allegro.tech.mongomigrationstream.infrastructure.mongo.MongoDbClients
 import pl.allegro.tech.mongomigrationstream.infrastructure.performer.PerformerFactory
 import pl.allegro.tech.mongomigrationstream.infrastructure.queue.QueueFactory
+import pl.allegro.tech.mongomigrationstream.infrastructure.sharding.ShardingInfoService
 
 internal class MigrationController(
     properties: ApplicationProperties,
@@ -17,9 +19,10 @@ internal class MigrationController(
     meterRegistry: MeterRegistry
 ) {
     private val mongoDbClients = MongoDbClients(properties, meterRegistry)
+    private val shardingInfo: ShardingInfo = ShardingInfoService.getShardingInfoFromDestinationDatabase(mongoDbClients)
     private val queues = QueueFactory.createQueues(properties)
     private val performers: List<Performer> =
-        PerformerFactory.createPerformers(properties, mongoDbClients, queues, stateInfo, meterRegistry)
+        PerformerFactory.createPerformers(properties, mongoDbClients, queues, stateInfo, shardingInfo, meterRegistry)
     private val synchronizationDetector = SynchronizationDetectorFactory(properties, mongoDbClients, queues, meterRegistry)
     private val performerController = PerformerController(performers, synchronizationDetector)
     private val migrationCleanup = MigrationCleanup(

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/infrastructure/mongo/MongoDbClients.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/infrastructure/mongo/MongoDbClients.kt
@@ -1,12 +1,14 @@
 package pl.allegro.tech.mongomigrationstream.infrastructure.mongo
 
+import com.mongodb.reactivestreams.client.MongoClient as ReactiveMongoClient
+import com.mongodb.reactivestreams.client.MongoDatabase as ReactiveMongoDatabase
 import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoDatabase
 import io.micrometer.core.instrument.MeterRegistry
 import pl.allegro.tech.mongomigrationstream.configuration.ApplicationProperties
 import pl.allegro.tech.mongomigrationstream.configuration.MongoProperties
-import com.mongodb.reactivestreams.client.MongoClient as ReactiveMongoClient
-import com.mongodb.reactivestreams.client.MongoDatabase as ReactiveMongoDatabase
+
+private const val CONFIG_DB = "config"
 
 internal class MongoDbClients(
     properties: ApplicationProperties,
@@ -25,6 +27,7 @@ internal class MongoDbClients(
         sourceClient.getDatabase(properties.sourceDbProperties.dbName)
     val destinationDatabase: MongoDatabase =
         destinationClient.getDatabase(properties.destinationDbProperties.dbName)
+    val destinationConfigDatabase: MongoDatabase = destinationClient.getDatabase(CONFIG_DB)
     val reactiveSourceDatabase: ReactiveMongoDatabase =
         reactiveSourceClient.getDatabase(properties.sourceDbProperties.dbName)
     val reactiveDestinationDatabase: ReactiveMongoDatabase =

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/infrastructure/mongo/MongoDbClients.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/infrastructure/mongo/MongoDbClients.kt
@@ -1,18 +1,18 @@
 package pl.allegro.tech.mongomigrationstream.infrastructure.mongo
 
-import com.mongodb.reactivestreams.client.MongoClient as ReactiveMongoClient
-import com.mongodb.reactivestreams.client.MongoDatabase as ReactiveMongoDatabase
 import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoDatabase
 import io.micrometer.core.instrument.MeterRegistry
 import pl.allegro.tech.mongomigrationstream.configuration.ApplicationProperties
 import pl.allegro.tech.mongomigrationstream.configuration.MongoProperties
+import com.mongodb.reactivestreams.client.MongoClient as ReactiveMongoClient
+import com.mongodb.reactivestreams.client.MongoDatabase as ReactiveMongoDatabase
 
 private const val CONFIG_DB = "config"
 
 internal class MongoDbClients(
     properties: ApplicationProperties,
-    meterRegistry: MeterRegistry
+    meterRegistry: MeterRegistry,
 ) {
     private val sourceClient: MongoClient =
         createDbClient(properties.sourceDbProperties, meterRegistry)
@@ -33,11 +33,15 @@ internal class MongoDbClients(
     val reactiveDestinationDatabase: ReactiveMongoDatabase =
         reactiveDestinationClient.getDatabase(properties.destinationDbProperties.dbName)
 
-    private fun createDbClient(mongoProperties: MongoProperties, meterRegistry: MeterRegistry): MongoClient =
-        MongoClientFactory.buildClient(mongoProperties, meterRegistry)
+    private fun createDbClient(
+        mongoProperties: MongoProperties,
+        meterRegistry: MeterRegistry,
+    ): MongoClient = MongoClientFactory.buildClient(mongoProperties, meterRegistry)
 
-    private fun createReactiveDbClient(mongoProperties: MongoProperties, meterRegistry: MeterRegistry): ReactiveMongoClient =
-        MongoClientFactory.buildReactiveClient(mongoProperties, meterRegistry)
+    private fun createReactiveDbClient(
+        mongoProperties: MongoProperties,
+        meterRegistry: MeterRegistry,
+    ): ReactiveMongoClient = MongoClientFactory.buildReactiveClient(mongoProperties, meterRegistry)
 
     fun closeClients() {
         sourceClient.close()

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/infrastructure/sharding/ShardingInfoService.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/infrastructure/sharding/ShardingInfoService.kt
@@ -1,0 +1,54 @@
+package pl.allegro.tech.mongomigrationstream.infrastructure.sharding
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.bson.Document
+import pl.allegro.tech.mongomigrationstream.core.mongo.DbCollection
+import pl.allegro.tech.mongomigrationstream.core.sharding.ShardingInfo
+import pl.allegro.tech.mongomigrationstream.infrastructure.mongo.MongoDbClients
+
+/*
+    This class is responsible for extracting sharding keys from destination database
+    It does so by querying "config.collections" collection, and parsing the output
+    The assumption is that sharding key is the first one in the "key" document
+    MongoDB reference: https://www.mongodb.com/docs/manual/reference/config-database/
+ */
+
+internal object ShardingInfoService {
+    private val logger = KotlinLogging.logger { }
+
+    fun getShardingInfoFromDestinationDatabase(mongoDbClients: MongoDbClients): ShardingInfo {
+        val shardingInfoMap = mutableMapOf<DbCollection, String>()
+        mongoDbClients.destinationConfigDatabase.getCollection("collections").find()
+            .forEach { document ->
+                val dbCollection: DbCollection? = dbNameDotCollectionNameToDbCollection(document)
+                val shardingKey: String? = getShardingKey(document)
+                if (dbCollection != null && shardingKey != null) {
+                    shardingInfoMap[dbCollection] = shardingKey
+                }
+            }
+
+        logger.info { "Info regarding sharding keys on destination database: $shardingInfoMap" }
+        return ShardingInfo(shardingInfoMap)
+    }
+
+    private fun dbNameDotCollectionNameToDbCollection(document: Document): DbCollection? {
+        try {
+            val dbNameDotCollectionName = document.getString("_id")
+            val (dbName, collectionName) = dbNameDotCollectionName.split(".")
+            return DbCollection(dbName, collectionName)
+        } catch (exception: Exception) {
+            logger.error(exception) { "Could not parse [${document.toJson()}] to retrieve dbName.collectionName" }
+            return null
+        }
+    }
+
+    private fun getShardingKey(document: Document): String? {
+        try {
+            val keyDocument: Map<*, *>? = document["key"] as Map<*, *>?
+            return keyDocument?.keys?.firstOrNull() as String?
+        } catch (exception: Exception) {
+            logger.error(exception) { "Could not parse [${document.toJson()}] to retrieve sharding key" }
+            return null
+        }
+    }
+}

--- a/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/infrastructure/sharding/ShardingInfoService.kt
+++ b/mongo-migration-stream-core/src/main/kotlin/pl/allegro/tech/mongomigrationstream/infrastructure/sharding/ShardingInfoService.kt
@@ -18,14 +18,18 @@ internal object ShardingInfoService {
 
     fun getShardingInfoFromDestinationDatabase(mongoDbClients: MongoDbClients): ShardingInfo {
         val shardingInfoMap = mutableMapOf<DbCollection, String>()
-        mongoDbClients.destinationConfigDatabase.getCollection("collections").find()
-            .forEach { document ->
-                val dbCollection: DbCollection? = dbNameDotCollectionNameToDbCollection(document)
-                val shardingKey: String? = getShardingKey(document)
-                if (dbCollection != null && shardingKey != null) {
-                    shardingInfoMap[dbCollection] = shardingKey
+        try {
+            mongoDbClients.destinationConfigDatabase.getCollection("collections").find()
+                .forEach { document ->
+                    val dbCollection: DbCollection? = dbNameDotCollectionNameToDbCollection(document)
+                    val shardingKey: String? = getShardingKey(document)
+                    if (dbCollection != null && shardingKey != null) {
+                        shardingInfoMap[dbCollection] = shardingKey
+                    }
                 }
-            }
+        } catch (exception: Exception) {
+            logger.error(exception) { "Error when getting sharding info from destination database." }
+        }
 
         logger.info { "Info regarding sharding keys on destination database: $shardingInfoMap" }
         return ShardingInfo(shardingInfoMap)


### PR DESCRIPTION
## What?
In this PR I've fixed the issue with syncing data to destination database which is sharded (when source database is not sharded).

## Why?
Because we need to also support this kind of migrations